### PR TITLE
Add default value to model initializer

### DIFF
--- a/lib/embedly/model.rb
+++ b/lib/embedly/model.rb
@@ -3,7 +3,9 @@ require 'ostruct'
 class Embedly::EmbedlyObject < OpenStruct
 
   # Resursively make ostruct
-  def initialize obj
+  # Default value added, this helps fix deserialization errors in Ruby 2.3+
+  # I'm not 100% sure why this is happening, but it looks like a change in YAML
+  def initialize obj = nil
     if obj
       o = obj.clone
       o.each do |k,v|

--- a/spec/embedly/serialize_spec.rb
+++ b/spec/embedly/serialize_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "yaml"
+
+describe Embedly::EmbedlyObject do
+  let(:serialized_embedly_object) do
+    "--- !ruby/object:Embedly::EmbedlyObject
+table:
+  :provider_url: https://www.youtube.com/"
+  end
+
+  subject { YAML.load(serialized_embedly_object) }
+
+  it "deserializes the EmbedlyObject" do
+    expect(subject).to be_a described_class
+  end
+
+end


### PR DESCRIPTION
This "fixes" the problem that's caused by upgrading to Ruby 2.3.1.
Still looking for a reason, why this works.
